### PR TITLE
Removed Notebook repository

### DIFF
--- a/.ipynb_checkpoints/EXES-Data-Inspection-checkpoint.ipynb
+++ b/.ipynb_checkpoints/EXES-Data-Inspection-checkpoint.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "#### You can download the example data directly [here](https://zenodo.org/record/6574619/files/iktau_feb2020_MRD.fits?download=1).\n",
     "\n",
-    "[EXES GO Handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf) for reference (latest version can be found on the [SOFIA Data Products](https://www.sofia.usra.edu/data/data-processing-0#DataHandbooks) page.)"
+    "[EXES GO Handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf) for reference (latest version can be found on the [SOFIA Data Products](https://www.sofia.usra.edu/data/data-processing-0#DataHandbooks) page.) "
    ]
   },
   {

--- a/.ipynb_checkpoints/EXES-Data-Inspection-checkpoint.ipynb
+++ b/.ipynb_checkpoints/EXES-Data-Inspection-checkpoint.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 grism data of the IK Tau. <br />\n",
     "* **Tools**: astropy<br />\n",
     "* **Instrument**: EXES<br />\n",
-    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)"
    ]
   },
   {
@@ -549,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/EXES-Telluric-Correction-checkpoint.ipynb
+++ b/.ipynb_checkpoints/EXES-Telluric-Correction-checkpoint.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 grism data of the Sirius. <br />\n",
     "* **Tools**: astropy, scipy, PSG <br />\n",
     "* **Instrument**: EXES <br />\n",
-    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)"
    ]
   },
   {
@@ -920,7 +919,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/FIFI-LS_sospex-checkpoint.ipynb
+++ b/.ipynb_checkpoints/FIFI-LS_sospex-checkpoint.ipynb
@@ -12,8 +12,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: SOSPEX <br />\n",
     "* **Instrument**: FIFI-LS <br />\n",
-    "* **Documentation**: [FIFI-LS data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FIFI-LSDataHandbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FIFI-LS data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FIFI-LSDataHandbook.pdf)"
    ]
   },
   {
@@ -338,7 +337,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/FORCAST-Basic_Photometry-checkpoint.ipynb
+++ b/.ipynb_checkpoints/FORCAST-Basic_Photometry-checkpoint.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: FORCAST imaging data (5.6um) of the Symbiotic Mira, HM Sge <br />\n",
     "* **Tools**: astropy, photutils <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -531,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/FORCAST-Grism_CustomExtraction-checkpoint.ipynb
+++ b/.ipynb_checkpoints/FORCAST-Grism_CustomExtraction-checkpoint.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 3 grism data of the Saturn Nebula (G111)<br />\n",
     "* **Tools**: astropy, DS9 <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -37,7 +36,7 @@
     "\n",
     "The extraction aperture for extended sources is generally set manually to include all the flux from the source and may not be exactly what the guest investigator (GI) needs for his or her science.  For our purposes the extraction aperture is simply the \"window\" in slit position [x_lo,x_hi] over which flux is summed at each wavelength to produce a 1-D spectrum (flux vs wavelength).  The final extracted 1-D spectrum is saved in a CAL file as usual (see [FORCAST Grism Recipe: Basic Inspection and Assessment](FORCAST-Grism_Inspection.ipynb) for review); in addition, the pipeline saves the wavelength-calibrated, recitifeid 2-D spectral image (from which the extraction is made) in a corresponding RIM file, with wavelength along the x-axis and slit position along the y-axis.  \n",
     "\n",
-    "In this recipe we show the user how to plot the aperture used on the 2-D spectral image and how to do a simple custom extraction using a different aperture if desired.  If a custom extraction is needed, we strongly encourage the GI to contact the [SOFIA Help Desk](mailto:sofia_help@sofia.usra.edu) and request re-reduction with the specifed aperture(s).  This ensures that the GI gets the best quality data using the latest pipeline routines."
+    "In this recipe we show the user how to plot the aperture used on the 2-D spectral image and how to do a simple custom extraction using a different aperture if desired."
    ]
   },
   {
@@ -515,7 +514,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/FORCAST-Grism_Inspection-checkpoint.ipynb
+++ b/.ipynb_checkpoints/FORCAST-Grism_Inspection-checkpoint.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 3 grism data of the Herbig Ae star, AB Aur (G063, G111, G227, and G329)<br />\n",
     "* **Tools**: astropy, DS9 <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -1430,7 +1429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/FORCAST-Grism_LineAnalysis-checkpoint.ipynb
+++ b/.ipynb_checkpoints/FORCAST-Grism_LineAnalysis-checkpoint.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 3 grism data of the Saturn Nebula (G111) <br />\n",
     "* **Tools**: astropy, specutils <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -878,7 +877,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/FORCAST-photometry_detailed-checkpoint.ipynb
+++ b/.ipynb_checkpoints/FORCAST-photometry_detailed-checkpoint.ipynb
@@ -9,8 +9,7 @@
     "=========================\n",
     "* **Aim**: A more-detailed description of the photometry process. <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -243,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/GREAT-Class_primer-checkpoint.ipynb
+++ b/.ipynb_checkpoints/GREAT-Class_primer-checkpoint.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: Class <br />\n",
     "* **Instrument**: GREAT <br />\n",
-    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)"
    ]
   },
   {
@@ -281,7 +280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/GREAT-data-inspection-checkpoint.ipynb
+++ b/.ipynb_checkpoints/GREAT-data-inspection-checkpoint.ipynb
@@ -8,11 +8,10 @@
     "GREAT: Data Inspection (Python)\n",
     "================\n",
     "* **Aim**: Load GREAT spectrum and complete basic baseline subtraction. <br />\n",
-    "* **Data**: Level 3 data. <br />\n",
+    "* **Data**: Level 4 data. <br />\n",
     "* **Tools**: astropy <br />\n",
     "* **Instrument**: GREAT <br />\n",
     "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes\n",
     "\n",
     "Code contributed by Ümit Kavak "
    ]
@@ -985,7 +984,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/.ipynb_checkpoints/GREAT-reproject-data-to-GREAT-resolution-checkpoint.ipynb
+++ b/.ipynb_checkpoints/GREAT-reproject-data-to-GREAT-resolution-checkpoint.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: astropy <br />\n",
     "* **Instrument**: GREAT <br />\n",
-    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)"
    ]
   },
   {
@@ -563,7 +562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/.ipynb_checkpoints/GREAT_Cubeviz-checkpoint.ipynb
+++ b/.ipynb_checkpoints/GREAT_Cubeviz-checkpoint.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: jdaviz, Cubeviz, Glue <br />\n",
     "* **Instrument**: GREAT <br />\n",
-    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)"
    ]
   },
   {
@@ -220,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/.ipynb_checkpoints/HAWC_30Dor-checkpoint.ipynb
+++ b/.ipynb_checkpoints/HAWC_30Dor-checkpoint.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 4 imaging polarimetry data for 30 Dor <br />\n",
     "* **Tools**: astropy <br />\n",
     "* **Instrument**: HAWC+<br />\n",
-    "* **Documentation**: [HAWC+ Data Handbook](https://www.sofia.usra.edu/sites/default/files/Instruments/HAWC_PLUS/Documents/hawc_data_handbook.pdf).\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [HAWC+ Data Handbook](https://www.sofia.usra.edu/sites/default/files/Instruments/HAWC_PLUS/Documents/hawc_data_handbook.pdf)."
    ]
   },
   {
@@ -944,7 +943,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/.ipynb_checkpoints/SOFIA_data_retrieval-checkpoint.ipynb
+++ b/.ipynb_checkpoints/SOFIA_data_retrieval-checkpoint.ipynb
@@ -9,8 +9,7 @@
     "* **Aim**: Download SOFIA data through the Infrared Science Archive [(IRSA)](https://irsa.ipac.caltech.edu/applications/sofia/)<br />\n",
     "* **Data**: 30 Doradus HAWC+ public dataset<br />\n",
     "* **Instrument**: All<br />\n",
-    "* **Documentation**: [Science Archive](https://www.sofia.usra.edu/data/science-archive).<br />\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [Science Archive](https://www.sofia.usra.edu/data/science-archive).<br />"
    ]
   },
   {
@@ -186,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/EXES-Data-Inspection.ipynb
+++ b/EXES-Data-Inspection.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "#### You can download the example data directly [here](https://zenodo.org/record/6574619/files/iktau_feb2020_MRD.fits?download=1).\n",
     "\n",
-    "[EXES GO Handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf) for reference (latest version can be found on the [SOFIA Data Products](https://www.sofia.usra.edu/data/data-processing-0#DataHandbooks) page.)"
+    "[EXES GO Handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf) for reference (latest version can be found on the [SOFIA Data Products](https://www.sofia.usra.edu/data/data-processing-0#DataHandbooks) page.) "
    ]
   },
   {

--- a/EXES-Data-Inspection.ipynb
+++ b/EXES-Data-Inspection.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 grism data of the IK Tau. <br />\n",
     "* **Tools**: astropy<br />\n",
     "* **Instrument**: EXES<br />\n",
-    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)"
    ]
   },
   {
@@ -549,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/EXES-Telluric-Correction.ipynb
+++ b/EXES-Telluric-Correction.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 grism data of the Sirius. <br />\n",
     "* **Tools**: astropy, scipy, PSG <br />\n",
     "* **Instrument**: EXES <br />\n",
-    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [EXES data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/EXES_GO-DataHandbook.pdf)"
    ]
   },
   {
@@ -920,7 +919,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/EXES-Velocity-Shift.ipynb
+++ b/EXES-Velocity-Shift.ipynb
@@ -163,7 +163,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/FIFI-LS_sospex.ipynb
+++ b/FIFI-LS_sospex.ipynb
@@ -12,8 +12,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: SOSPEX <br />\n",
     "* **Instrument**: FIFI-LS <br />\n",
-    "* **Documentation**: [FIFI-LS data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FIFI-LSDataHandbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FIFI-LS data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FIFI-LSDataHandbook.pdf)"
    ]
   },
   {
@@ -338,7 +337,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/FORCAST-Basic_Photometry.ipynb
+++ b/FORCAST-Basic_Photometry.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: FORCAST imaging data (5.6um) of the Symbiotic Mira, HM Sge <br />\n",
     "* **Tools**: astropy, photutils <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -531,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/FORCAST-Grism_CustomExtraction.ipynb
+++ b/FORCAST-Grism_CustomExtraction.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 3 grism data of the Saturn Nebula (G111)<br />\n",
     "* **Tools**: astropy, DS9 <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -37,7 +36,7 @@
     "\n",
     "The extraction aperture for extended sources is generally set manually to include all the flux from the source and may not be exactly what the guest investigator (GI) needs for his or her science.  For our purposes the extraction aperture is simply the \"window\" in slit position [x_lo,x_hi] over which flux is summed at each wavelength to produce a 1-D spectrum (flux vs wavelength).  The final extracted 1-D spectrum is saved in a CAL file as usual (see [FORCAST Grism Recipe: Basic Inspection and Assessment](FORCAST-Grism_Inspection.ipynb) for review); in addition, the pipeline saves the wavelength-calibrated, recitifeid 2-D spectral image (from which the extraction is made) in a corresponding RIM file, with wavelength along the x-axis and slit position along the y-axis.  \n",
     "\n",
-    "In this recipe we show the user how to plot the aperture used on the 2-D spectral image and how to do a simple custom extraction using a different aperture if desired.  If a custom extraction is needed, we strongly encourage the GI to contact the [SOFIA Help Desk](mailto:sofia_help@sofia.usra.edu) and request re-reduction with the specifed aperture(s).  This ensures that the GI gets the best quality data using the latest pipeline routines."
+    "In this recipe we show the user how to plot the aperture used on the 2-D spectral image and how to do a simple custom extraction using a different aperture if desired."
    ]
   },
   {
@@ -515,7 +514,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/FORCAST-Grism_Inspection.ipynb
+++ b/FORCAST-Grism_Inspection.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 3 grism data of the Herbig Ae star, AB Aur (G063, G111, G227, and G329)<br />\n",
     "* **Tools**: astropy, DS9 <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -1430,7 +1429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/FORCAST-Grism_LineAnalysis.ipynb
+++ b/FORCAST-Grism_LineAnalysis.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 3 grism data of the Saturn Nebula (G111) <br />\n",
     "* **Tools**: astropy, specutils <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -878,7 +877,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/FORCAST-photometry_detailed.ipynb
+++ b/FORCAST-photometry_detailed.ipynb
@@ -9,8 +9,7 @@
     "=========================\n",
     "* **Aim**: A more-detailed description of the photometry process. <br />\n",
     "* **Instrument**: FORCAST<br />\n",
-    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [FORCAST data handbook](https://www.sofia.usra.edu/sites/default/files/USpot_DCS_DPS/Documents/FORCAST_data_handbook.pdf)"
    ]
   },
   {
@@ -243,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/GREAT-Class_primer.ipynb
+++ b/GREAT-Class_primer.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: Class <br />\n",
     "* **Instrument**: GREAT <br />\n",
-    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)"
    ]
   },
   {
@@ -281,7 +280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/GREAT-data-inspection.ipynb
+++ b/GREAT-data-inspection.ipynb
@@ -8,11 +8,10 @@
     "GREAT: Data Inspection (Python)\n",
     "================\n",
     "* **Aim**: Load GREAT spectrum and complete basic baseline subtraction. <br />\n",
-    "* **Data**: Level 3 data. <br />\n",
+    "* **Data**: Level 4 data. <br />\n",
     "* **Tools**: astropy <br />\n",
     "* **Instrument**: GREAT <br />\n",
     "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes\n",
     "\n",
     "Code contributed by Ümit Kavak "
    ]
@@ -985,7 +984,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/GREAT-reproject-data-to-GREAT-resolution.ipynb
+++ b/GREAT-reproject-data-to-GREAT-resolution.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: astropy <br />\n",
     "* **Instrument**: GREAT <br />\n",
-    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)"
    ]
   },
   {
@@ -563,7 +562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/GREAT_Cubeviz.ipynb
+++ b/GREAT_Cubeviz.ipynb
@@ -11,8 +11,7 @@
     "* **Data**: Level 3 data. <br />\n",
     "* **Tools**: jdaviz, Cubeviz, Glue <br />\n",
     "* **Instrument**: GREAT <br />\n",
-    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [GREAT observer's handbook](https://www.sofia.usra.edu/instruments/great)"
    ]
   },
   {
@@ -220,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/HAWC_30Dor.ipynb
+++ b/HAWC_30Dor.ipynb
@@ -10,8 +10,7 @@
     "* **Data**: Level 4 imaging polarimetry data for 30 Dor <br />\n",
     "* **Tools**: astropy <br />\n",
     "* **Instrument**: HAWC+<br />\n",
-    "* **Documentation**: [HAWC+ Data Handbook](https://www.sofia.usra.edu/sites/default/files/Instruments/HAWC_PLUS/Documents/hawc_data_handbook.pdf).\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [HAWC+ Data Handbook](https://www.sofia.usra.edu/sites/default/files/Instruments/HAWC_PLUS/Documents/hawc_data_handbook.pdf)."
    ]
   },
   {
@@ -944,7 +943,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/SOFIA_data_retrieval.ipynb
+++ b/SOFIA_data_retrieval.ipynb
@@ -9,8 +9,7 @@
     "* **Aim**: Download SOFIA data through the Infrared Science Archive [(IRSA)](https://irsa.ipac.caltech.edu/applications/sofia/)<br />\n",
     "* **Data**: 30 Doradus HAWC+ public dataset<br />\n",
     "* **Instrument**: All<br />\n",
-    "* **Documentation**: [Science Archive](https://www.sofia.usra.edu/data/science-archive).<br />\n",
-    "* **Notebook repository**: https://github.com/SOFIAObservatory/Recipes"
+    "* **Documentation**: [Science Archive](https://www.sofia.usra.edu/data/science-archive).<br />"
    ]
   },
   {
@@ -186,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Removed Notebook repository link for each notebook. There will still be some links that will be broken when we transfer the account. This includes the handbooks and relative links to other notebooks. Zenodo links will remain active. 